### PR TITLE
Allow multiple fields of table

### DIFF
--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -19,7 +19,7 @@ class Configuration
         return $this->getSettings();
     }
 
-    public function getField(string $tableName): string
+    public function getField(string $tableName): array
     {
         $settings = $this->getSettings();
         return $settings[$tableName] ?? '';
@@ -38,7 +38,7 @@ class Configuration
                 if (count($split) !== 2) {
                     continue;
                 }
-                $settings[$split[0]] = $split[1];
+                $settings[$split[0]][] = $split[1];
             }
             return $settings;
         } catch (ExtensionConfigurationExtensionNotConfiguredException $e) {

--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -22,7 +22,7 @@ class Configuration
     public function getField(string $tableName): array
     {
         $settings = $this->getSettings();
-        return $settings[$tableName] ?? '';
+        return $settings[$tableName] ?? [];
     }
 
     /**

--- a/Classes/Xclass/XclassedDatabaseRecordList.php
+++ b/Classes/Xclass/XclassedDatabaseRecordList.php
@@ -76,7 +76,14 @@ class XclassedDatabaseRecordList extends DatabaseRecordList {
                 }
 
                 if ($thumbnailField) {
-                    $fullRow = isset($row[$thumbnailField]) ? $row : BackendUtility::getRecord($table, $row['uid']);
+                    foreach($thumbnailFields as $thumbField){
+                        $thumbnailField = $thumbField;
+                        $fullRow = isset($row[$thumbnailField]) ? $row : BackendUtility::getRecord($table, $row['uid']);
+                        
+                        if(!empty($fullRow[$thumbnailField])){
+                            break;
+                        }
+                    }
 
                     $thumbCode = '<br />' . BackendUtility::thumbCode($fullRow, $table, $thumbnailField);
                     $theData[$fCol] .= $thumbCode;
@@ -158,7 +165,7 @@ class XclassedDatabaseRecordList extends DatabaseRecordList {
         return $rowOutput;
     }
 
-    protected function getThumbnailField(string $tableName): string
+    protected function getThumbnailField(string $tableName): array
     {
         return GeneralUtility::makeInstance(Configuration::class)->getField($tableName);
     }


### PR DESCRIPTION
Multiple fields as a fallback are now possible in the extension configuration.
The first field that isn't empty will be picked to show the thumbnails.